### PR TITLE
Remove personal phone number from public portfolio

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -7,8 +7,7 @@ title: "Dr. Amy C. Rager"
 
 <!-- **Gov Email**: amy.c.rager@nasa.gov  
 **Corp Email**: amy.rager@gd-ms.com   -->
-**Phone**: 410-446-6502  
-**Address**: Columbia, Maryland 
+**Address**: Columbia, Maryland
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes the personal phone number (`410-446-6502`) from `index.markdown`, which was publicly visible on the live site
- Keeps the city/state address line, which is low-risk

## Test plan
- [ ] Merge into `main`
- [ ] Visit https://acrager.github.io and confirm no phone number appears on the page

https://claude.ai/code/session_01NZo88uDGc6bxTdMvwv8Ueu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZo88uDGc6bxTdMvwv8Ueu)_